### PR TITLE
Add minimum version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The extension is licensed under [AGPL-3.0](LICENSE.txt).
 ## Requirements
 
 * PHP v5.4+
-* CiviCRM (*FIXME: Version number*)
+* CiviCRM 5.65.0
 
 ## Installation (Web UI)
 


### PR DESCRIPTION
Not sure if this is actually the minimum version but we are using the extension on agsm and they are on the oldest secure version which is 5.65.0